### PR TITLE
Add A2AS Certificate

### DIFF
--- a/a2as.yaml
+++ b/a2as.yaml
@@ -1,0 +1,91 @@
+manifest:
+  version: "0.1.3"
+  schema: https://a2as.org/cert/schema
+  subject:
+    name: arjunprabhulal/adk-github-agent
+    source: https://github.com/arjunprabhulal/adk-github-agent
+    branch: main
+    commit: "60f12e2a"
+    scope: [github-agent/agent.py]
+  issued:
+    by: A2AS.org
+    at: '2026-02-11T16:54:55Z'
+    url: https://a2as.org/certified/agents/arjunprabhulal/adk-github-agent
+  signatures:
+    digest: sha256:j2rS-N8klWFfr0sgCDr6ahldrFyMNzM769ul5w8P4k0
+    key: ed25519:DCUVtnFjg_RndHeV6quQRpE1YbcFDF2-VL9CXra9KhU
+    sig: ed25519:GACSz8rFBd5Zh0H_5SPhvJ3HUnJgZKplo0Dcgj12htM3kwqx6UjEZHFTjE9XR4kEdI08xeyEPZHGIOcSWaAyDQ
+
+agents:
+  github_agent:
+    type: instance
+    models: [gemini-2.5-pro-preview-03-25]
+    tools: [tools]
+    params:
+      name: github_agent
+      description: GitHub API Agent
+      instruction: [You are a GitHub API agent that interacts with GitHub's REST API., 'When working with the GitHub API:',
+        '- Use parameters provided by the user', '- Ask for clarification if required parameters are missing', '- Format responses
+          clearly for the user', '- Handle errors gracefully and explain issues in simple terms', 'For content creation operations:',
+        '- Use names and identifiers exactly as specified by the user', '- Add helpful descriptions when allowed by the API',
+        '- Apply sensible defaults for optional parameters when not specified', Always inform the user about the actions you're
+          taking and the results received.]
+      function: create_github_agent
+
+models:
+  gemini-2.5-pro-preview-03-25:
+    type: literal
+    agents: [github_agent]
+
+tools:
+  tools:
+    type: function
+    agents: [github_agent]
+    params:
+      dynamic: "True"
+
+imports:
+  Agent: google.adk.agents.Agent
+  agent: agent
+  json: json
+  logging: logging
+  OpenAPIToolset: google.adk.tools.openapi_tool.openapi_spec_parser.openapi_toolset.OpenAPIToolset
+  os: os
+  sys: sys
+  token_to_scheme_credential: google.adk.tools.openapi_tool.auth.auth_helpers.token_to_scheme_credential
+
+functions:
+  create_github_agent:
+    type: sync
+    module: github-agent.agent
+    args: [api_spec_path, token_env_var, auth_prefix]
+  load_api_spec:
+    type: sync
+    module: github-agent.agent
+    args: [path]
+
+variables:
+  token_env_var:
+    type: env
+    params:
+      caller: [os.getenv]
+      path: [github-agent.agent]
+
+files:
+  api.github.com.fixed.json:
+    type: pattern
+    actions: [read]
+    params:
+      caller: [os.path.join]
+      pattern: [os.path.dirname(), api.github.com.fixed.json]
+  api_spec_path:
+    type: variable
+    actions: [read]
+    params:
+      caller: [os.path.exists]
+  path:
+    type: variable
+    actions: [read]
+    params:
+      caller: [open, json.load]
+      alias: [f]


### PR DESCRIPTION
# Add A2AS Certificate for Agent Transparency and Security

## Summary

This PR adds an agent certificate using the A2AS format - an open standard for agentic AI security. The certificate declares operational boundaries, agentic actions, and resources. It acts as a transparency artifact for your agent.

This repository has been certified and added to the registry. 

Info and visualization available via the link or badge: 

[A2AS.org/certified/agents/arjunprabhulal/adk-github-agent](https://www.a2as.org/certified/agents/arjunprabhulal/adk-github-agent?utm_source=github&utm_medium=pull_request)

[![A2AS-CERTIFIED](https://img.shields.io/badge/A2AS-CERTIFIED-f3af80)](https://www.a2as.org/certified/agents/arjunprabhulal/adk-github-agent?utm_source=github&utm_medium=pull_request) 



## About A2AS Certificates

A2AS certificates are declarative manifests for agent behavior. They describe what an agent is designed to do:

- AI level: agents, models, tools, resources
- APP level: imports, functions, variables
- OS level: files, networks, processes

Certificates are human-readable and machine-readable, and can be used as a transparency and security artifact.

The A2AS standard is a project from the [A2AS.org](https://a2as.org/?utm_source=github&utm_medium=pull_request) initiative led by experts from big tech and security companies.



## Benefits For This Project

This A2AS certificate can help to:

- Make it easier for contributors to see what the agent does
- Increase trust in your agent by making its behavior explicit
- Grow adoption with security-conscious and enterprise users



## What This PR Does

This PR doesn't change any code:

- Only adds `a2as.yaml` to the repository root
- Aligns the certificate with the current agent logic
- Does not modify agent code, prompts, or configuration



## Optional Next Steps

When the agent changes, the A2AS certificate is expected to be updated.

A2AS project maintainers can help with updating the certificate as your agent evolves.

If you find this relevant, you can add the A2AS Shield to your README.md file:

[![A2AS-CERTIFIED](https://img.shields.io/badge/A2AS-CERTIFIED-f3af80)](https://www.a2as.org/certified/agents/arjunprabhulal/adk-github-agent?utm_source=github&utm_medium=pull_request) 
